### PR TITLE
Example Braze integration

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,7 +3,23 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'io.ionic.starter',
   appName: 'SampleApp',
-  webDir: 'www'
+  webDir: 'www',
+  cordova: {
+    // Needed for Capacitor < 7.0.0 to allows access to the BrazePlugin module in the native code.
+    // The `staticPlugins` configuration can be omitted in Capacitor 7.x.x+ projects.
+    staticPlugins: [
+      'cordova-plugin-braze'
+    ],
+    // Braze specific configuration goes here
+    // See the following links for available configuration keys:
+    // - https://www.braze.com/docs/developer_guide/platforms/cordova/sdk_integration/#optional-configurations
+    preferences: {
+      'com.braze.api_key': 'BRAZE_API_KEY',
+      'com.braze.ios_api_endpoint': 'BRAZE_ENDPOINT',
+      // Debug log level:
+      'com.braze.ios_log_level': '0',
+    },
+  },
 };
 
 export default config;

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -14,7 +14,7 @@ const config: CapacitorConfig = {
     // See the following links for available configuration keys:
     // - https://www.braze.com/docs/developer_guide/platforms/cordova/sdk_integration/#optional-configurations
     preferences: {
-      'com.braze.api_key': 'BRAZE_API_KEY',
+      'com.braze.ios_api_key': 'BRAZE_API_KEY',
       'com.braze.ios_api_endpoint': 'BRAZE_ENDPOINT',
       // Debug log level:
       'com.braze.ios_log_level': '0',

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 				504EC3011FED79650016851F /* Frameworks */,
 				504EC3021FED79650016851F /* Resources */,
 				9592DBEFFC6D2A0C8D5DEB22 /* [CP] Embed Pods Frameworks */,
+				5F02D82FA8EBC6528A37F7E1 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -141,8 +142,6 @@
 				Base,
 			);
 			mainGroup = 504EC2FB1FED79650016851F;
-			packageReferences = (
-			);
 			productRefGroup = 504EC3051FED79650016851F /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -169,6 +168,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		5F02D82FA8EBC6528A37F7E1 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-App/Pods-App-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		6634F4EFEBD30273BCE97C65 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -1,5 +1,8 @@
 import UIKit
 import Capacitor
+// If you need access to the Braze SDK instance, import the `CordovaPluginsStatic` module.
+// To access the Braze SDK instance, use the `BrazePlugin.braze()` method.
+import CordovaPluginsStatic
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -15,6 +15,7 @@ def capacitor_pods
   pod 'CapacitorHaptics', :path => '../../node_modules/@capacitor/haptics'
   pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
+  pod 'CordovaPluginsStatic', :path => '../capacitor-cordova-ios-plugins'
 end
 
 target 'App' do

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -1,4 +1,9 @@
 PODS:
+  - BrazeKit (10.1.0)
+  - BrazeLocation (10.1.0):
+    - BrazeKit (= 10.1.0)
+  - BrazeUI (10.1.0):
+    - BrazeKit (= 10.1.0)
   - Capacitor (7.0.1):
     - CapacitorCordova
   - CapacitorApp (7.0.0):
@@ -10,6 +15,11 @@ PODS:
     - Capacitor
   - CapacitorStatusBar (7.0.0):
     - Capacitor
+  - CordovaPluginsStatic (7.0.1):
+    - BrazeKit (~> 10.1.0)
+    - BrazeLocation (~> 10.1.0)
+    - BrazeUI (~> 10.1.0)
+    - CapacitorCordova
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -18,6 +28,13 @@ DEPENDENCIES:
   - "CapacitorHaptics (from `../../node_modules/@capacitor/haptics`)"
   - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
   - "CapacitorStatusBar (from `../../node_modules/@capacitor/status-bar`)"
+  - CordovaPluginsStatic (from `../capacitor-cordova-ios-plugins`)
+
+SPEC REPOS:
+  trunk:
+    - BrazeKit
+    - BrazeLocation
+    - BrazeUI
 
 EXTERNAL SOURCES:
   Capacitor:
@@ -32,15 +49,21 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/keyboard"
   CapacitorStatusBar:
     :path: "../../node_modules/@capacitor/status-bar"
+  CordovaPluginsStatic:
+    :path: "../capacitor-cordova-ios-plugins"
 
 SPEC CHECKSUMS:
+  BrazeKit: 6ad539cc8cfd2760c0e1974df17362b8a5c97dbc
+  BrazeLocation: e84bbd252a7629e170fab497f7bf20b1ee8ce399
+  BrazeUI: 6516c7a30396a3b338a685f9b79beea8204ff3ea
   Capacitor: 23fff43571a4d1e3ee7d67b5a3588c6e757c2913
   CapacitorApp: 45cb7cbef4aa380b9236fd6980033eb5cde6fcd2
   CapacitorCordova: 63d476958d5022d76f197031e8b7ea3519988c64
   CapacitorHaptics: 1fba3e460e7614349c6d5f868b1fccdc5c87b66d
   CapacitorKeyboard: 2c26c6fccde35023c579fc37d4cae6326d5e6343
   CapacitorStatusBar: 438e90beeeefa8276b24e6c5991cb02dd13e51bf
+  CordovaPluginsStatic: 4dd9b1a76217d3c630591d3b87b6c9486c6d08c3
 
-PODFILE CHECKSUM: f8c95c38f42283ff8d7c6bf6fa1435ecdce85ae9
+PODFILE CHECKSUM: 2fde40b4adb26836a809ff586d1909a3f8a5ee54
 
 COCOAPODS: 1.16.1

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - BrazeKit (10.1.0)
-  - BrazeLocation (10.1.0):
-    - BrazeKit (= 10.1.0)
-  - BrazeUI (10.1.0):
-    - BrazeKit (= 10.1.0)
+  - BrazeKit (11.6.1)
+  - BrazeLocation (11.6.1):
+    - BrazeKit (= 11.6.1)
+  - BrazeUI (11.6.1):
+    - BrazeKit (= 11.6.1)
   - Capacitor (7.0.1):
     - CapacitorCordova
   - CapacitorApp (7.0.0):
@@ -16,9 +16,9 @@ PODS:
   - CapacitorStatusBar (7.0.0):
     - Capacitor
   - CordovaPluginsStatic (7.0.1):
-    - BrazeKit (~> 10.1.0)
-    - BrazeLocation (~> 10.1.0)
-    - BrazeUI (~> 10.1.0)
+    - BrazeKit (~> 11.6.1)
+    - BrazeLocation (~> 11.6.1)
+    - BrazeUI (~> 11.6.1)
     - CapacitorCordova
 
 DEPENDENCIES:
@@ -53,17 +53,17 @@ EXTERNAL SOURCES:
     :path: "../capacitor-cordova-ios-plugins"
 
 SPEC CHECKSUMS:
-  BrazeKit: 6ad539cc8cfd2760c0e1974df17362b8a5c97dbc
-  BrazeLocation: e84bbd252a7629e170fab497f7bf20b1ee8ce399
-  BrazeUI: 6516c7a30396a3b338a685f9b79beea8204ff3ea
-  Capacitor: 23fff43571a4d1e3ee7d67b5a3588c6e757c2913
-  CapacitorApp: 45cb7cbef4aa380b9236fd6980033eb5cde6fcd2
+  BrazeKit: 190a4d8bb1f0405e885cdd35c53726702aed4e89
+  BrazeLocation: 2e0c198f30a9e8b56a6331794a69dad40abb7c03
+  BrazeUI: 41fc2e9ce0dd057e0ace9a9657404accf97f7339
+  Capacitor: de199cba6c8b20995428ad0b7cb0bc6ca625ffd4
+  CapacitorApp: 9cb31064a6c6bb2b1438583733a7bf45557fc1da
   CapacitorCordova: 63d476958d5022d76f197031e8b7ea3519988c64
-  CapacitorHaptics: 1fba3e460e7614349c6d5f868b1fccdc5c87b66d
-  CapacitorKeyboard: 2c26c6fccde35023c579fc37d4cae6326d5e6343
-  CapacitorStatusBar: 438e90beeeefa8276b24e6c5991cb02dd13e51bf
-  CordovaPluginsStatic: 4dd9b1a76217d3c630591d3b87b6c9486c6d08c3
+  CapacitorHaptics: 7be406a91e4eb87287f321c6c68e1709d6837b3a
+  CapacitorKeyboard: 4db71e694e7afb5d7c0be09b05495c19f7d6c914
+  CapacitorStatusBar: a8c4c83ed2e973bdafb979e80e4b00d027832cb7
+  CordovaPluginsStatic: fb956425636506ae904f96842cee3145e6bf66c8
 
 PODFILE CHECKSUM: 2fde40b4adb26836a809ff586d1909a3f8a5ee54
 
-COCOAPODS: 1.16.1
+COCOAPODS: 1.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@capacitor/keyboard": "7.0.0",
         "@capacitor/status-bar": "7.0.0",
         "@ionic/angular": "^8.0.0",
+        "braze-cordova-sdk": "github:braze-inc/braze-cordova-sdk",
         "ionicons": "^7.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -7312,6 +7313,10 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/braze-cordova-sdk": {
+      "version": "10.0.0",
+      "resolved": "git+ssh://git@github.com/braze-inc/braze-cordova-sdk.git#65601c0d9a9053bdd19425d3e9fb6baced1e9e49"
     },
     "node_modules/browserslist": {
       "version": "4.24.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@capacitor/keyboard": "7.0.0",
         "@capacitor/status-bar": "7.0.0",
         "@ionic/angular": "^8.0.0",
-        "braze-cordova-sdk": "github:braze-inc/braze-cordova-sdk",
+        "braze-cordova-sdk": "github:braze-inc/braze-cordova-sdk#11.0.0",
         "ionicons": "^7.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -7315,8 +7315,8 @@
       }
     },
     "node_modules/braze-cordova-sdk": {
-      "version": "10.0.0",
-      "resolved": "git+ssh://git@github.com/braze-inc/braze-cordova-sdk.git#65601c0d9a9053bdd19425d3e9fb6baced1e9e49"
+      "version": "11.0.0",
+      "resolved": "git+ssh://git@github.com/braze-inc/braze-cordova-sdk.git#1e4a2877b1149bd0837a8757771b7382080260d5"
     },
     "node_modules/browserslist": {
       "version": "4.24.4",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@capacitor/keyboard": "7.0.0",
     "@capacitor/status-bar": "7.0.0",
     "@ionic/angular": "^8.0.0",
+    "braze-cordova-sdk": "github:braze-inc/braze-cordova-sdk",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@capacitor/keyboard": "7.0.0",
     "@capacitor/status-bar": "7.0.0",
     "@ionic/angular": "^8.0.0",
-    "braze-cordova-sdk": "github:braze-inc/braze-cordova-sdk",
+    "braze-cordova-sdk": "github:braze-inc/braze-cordova-sdk#11.0.0",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/src/app/tab1/tab1.page.ts
+++ b/src/app/tab1/tab1.page.ts
@@ -1,5 +1,9 @@
 import { Component } from '@angular/core';
 
+// Import the BrazePlugin module, we use the `// @ts-ignore` comment below to ignore the TypeScript error
+// @ts-ignore
+import * as BrazePlugin from 'braze-cordova-sdk';
+
 @Component({
   selector: 'app-tab1',
   templateUrl: 'tab1.page.html',
@@ -11,7 +15,11 @@ export class Tab1Page {
   constructor() {}
 
   logCustomEvent() {
-    console.log("log custom event")
+    // Example of use of the BrazePlugin API
+    // See:
+    // - BrazePlugin symbols: https://github.com/braze-inc/braze-cordova-sdk/blob/master/www/BrazePlugin.js
+    // - Example usage: https://github.com/braze-inc/braze-cordova-sdk/blob/master/sample-project/www/js/index.js
+    BrazePlugin.logCustomEvent("test_event", { "test_key": "test_value" });
   }
 
 }


### PR DESCRIPTION
This PR shows how to integrate the https://github.com/braze-inc/braze-cordova-sdk in a Ionic / Capacitor / Angular application.

In an existing project:
1. `npm install https://github.com/braze-inc/braze-cordova-sdk`
    - To install a specific version of the Braze Cordova SDK, add `#VERSION` at the end of the URL
    - e.g. `npm install https://github.com/braze-inc/braze-cordova-sdk#11.0.0`
3. `npx cap sync`
4. Modify [`capacitor.config.ts`](https://github.com/lowip/braze-cordova-ionic-capacitor-angular-sample/pull/1/files#diff-cc7bbd9d83faa38b4df37d38bfa2a22f9154663864dec880283b29423be70cc9) like in this PR
5. To use the `BrazePlugin` in your project, refer to [`tab1.page.ts`](https://github.com/lowip/braze-cordova-ionic-capacitor-angular-sample/pull/1/files#diff-cc2eb36e42d085f18a5d23d33264541fe34aaa5d7203ebfd6af8e1e6eef5d269) like in this PR
6. (Optional) If you need access to the Braze SDK instance in the native side, refer to the [`AppDelegate.swift`](https://github.com/lowip/braze-cordova-ionic-capacitor-angular-sample/pull/1/files#diff-b3d33b076cd75a857a3a4420b5cdbaa1d565191370a89f6f91466878cab222ee) modifications.
